### PR TITLE
Change base image to Ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 LABEL maintainer="Kirill Plotnikov <init@pltnk.dev>" \
       github="https://github.com/pltnk/docker-liquidsoap"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:focal
 LABEL maintainer="Kirill Plotnikov <init@pltnk.dev>" \
       github="https://github.com/pltnk/docker-liquidsoap"
 
-ENV OCAML_VERSION "4.08.0"
+ENV OCAML_VERSION "4.11.1"
 ENV OPAM_PACKAGES "taglib mad lame vorbis cry samplerate liquidsoap"
 
 # install liquidsoap dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,8 @@ ENV OPAM_PACKAGES "taglib mad lame vorbis cry samplerate liquidsoap"
 
 # install liquidsoap dependencies
 RUN apt update && apt upgrade -y && \
-    apt install -y software-properties-common && \
-    add-apt-repository ppa:avsm/ppa && \
-    apt update && \
-    apt install -y opam \
+    apt install -y \
+    opam \
     gcc \
     libmad0-dev \
     libmp3lame-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer="Kirill Plotnikov <init@pltnk.dev>" \
 
 ENV OCAML_VERSION "4.11.1"
 ENV OPAM_PACKAGES "taglib mad lame vorbis cry samplerate liquidsoap"
+ENV DEBIAN_FRONTEND=noninteractive
 
 # install liquidsoap dependencies
 RUN apt update && apt upgrade -y && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM ubuntu:focal
 LABEL maintainer="Kirill Plotnikov <init@pltnk.dev>" \
       github="https://github.com/pltnk/docker-liquidsoap"
 
-ENV OCAML_VERSION "4.11.1"
 ENV OPAM_PACKAGES "taglib mad lame vorbis cry samplerate liquidsoap"
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -33,7 +32,7 @@ RUN groupadd -g 999 radio && \
 USER radio
 
 # setup opam
-RUN opam init -a -y -c ${OCAML_VERSION} --disable-sandboxing && \
+RUN opam init -a -y --disable-sandboxing && \
     eval $(opam env) && \
     opam install -y depext
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 ## docker-liquidsoap
+[![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/pltnk/liquidsoap)](https://hub.docker.com/r/pltnk/liquidsoap)
+[![Docker Image Size](https://img.shields.io/docker/image-size/pltnk/liquidsoap)](https://hub.docker.com/r/pltnk/liquidsoap)
+[![Docker Pulls](https://img.shields.io/docker/pulls/pltnk/liquidsoap)](https://hub.docker.com/r/pltnk/liquidsoap)
+[![Docker Cloud Automated build](https://img.shields.io/docker/cloud/automated/pltnk/liquidsoap)](https://hub.docker.com/r/pltnk/liquidsoap)
+
 Dockerfile for running [Liquidsoap](https://www.liquidsoap.info/) in a container. \
 Just mount your Liquidsoap script, music directory and you are good to go!
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 ## docker-liquidsoap
+
 [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/pltnk/liquidsoap)](https://hub.docker.com/r/pltnk/liquidsoap)
 [![Docker Image Size](https://img.shields.io/docker/image-size/pltnk/liquidsoap)](https://hub.docker.com/r/pltnk/liquidsoap)
 [![Docker Pulls](https://img.shields.io/docker/pulls/pltnk/liquidsoap)](https://hub.docker.com/r/pltnk/liquidsoap)
 [![Docker Cloud Automated build](https://img.shields.io/docker/cloud/automated/pltnk/liquidsoap)](https://hub.docker.com/r/pltnk/liquidsoap)
+[![License](https://img.shields.io/github/license/pltnk/docker-liquidsoap)](https://choosealicense.com/licenses/mit/)
 
 Dockerfile for running [Liquidsoap](https://www.liquidsoap.info/) in a container. \
 Just mount your Liquidsoap script, music directory and you are good to go!

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Docker Image Size](https://img.shields.io/docker/image-size/pltnk/liquidsoap)](https://hub.docker.com/r/pltnk/liquidsoap)
 [![Docker Pulls](https://img.shields.io/docker/pulls/pltnk/liquidsoap)](https://hub.docker.com/r/pltnk/liquidsoap)
 [![Docker Cloud Automated build](https://img.shields.io/docker/cloud/automated/pltnk/liquidsoap)](https://hub.docker.com/r/pltnk/liquidsoap)
-[![License](https://img.shields.io/github/license/pltnk/docker-liquidsoap)](https://choosealicense.com/licenses/mit/)
+[![License](https://img.shields.io/github/license/pltnk/docker-liquidsoap)](https://github.com/pltnk/docker-liquidsoap/blob/master/LICENSE)
 
 Dockerfile for running [Liquidsoap](https://www.liquidsoap.info/) in a container. \
 Just mount your Liquidsoap script, music directory and you are good to go!


### PR DESCRIPTION
### Changed:
- Version of Ubuntu was changed from 18.04 to 20.04. Dockerfile that is based on Ubuntu 18.04 is available in [bionic branch](https://github.com/pltnk/docker-liquidsoap/tree/bionic). Built image on Docker Hub will be available by `bionic` tag.