### PR TITLE
Fix for 2.2.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM debian:bookworm-slim
 
 LABEL maintainer="Kirill Plotnikov <init@pltnk.dev>" \
       github="https://github.com/pltnk/docker-liquidsoap"
@@ -10,11 +10,21 @@ RUN apt update && apt upgrade -y && \
     apt install -y \
     opam \
     gcc \
+    libavcodec-dev \
+    libavdevice-dev \
+    libavfilter-dev \
+    libavformat-dev \
+    libavutil-dev \
+    libjemalloc-dev \
+    libswresample-dev \
+    libswscale-dev \
+    libcurl4-gnutls-dev \
     libmad0-dev \
     libmp3lame-dev \
     libogg-dev \
     libpcre3-dev \
     libsamplerate0-dev \
+    libssl-dev \
     libtag1-dev \
     libvorbis-dev \
     m4 \
@@ -24,25 +34,22 @@ RUN apt update && apt upgrade -y && \
     apt autoremove && apt clean && \
     rm -rf /var/lib/apt/lists/*
 
+ARG LIQUIDSOAP_VERSION
+ARG OPAM_PACKAGES="liquidsoap${LIQUIDSOAP_VERSION:+.$LIQUIDSOAP_VERSION} taglib mad lame vorbis cry samplerate ssl ffmpeg jemalloc"
+
 # add user for liquidsoap and create necessary directories
 RUN groupadd -g 999 radio && \
     useradd -m -r -u 999 -s /bin/bash -g radio radio && \
     mkdir /etc/liquidsoap /music && \
     chown -R radio /etc/liquidsoap /music
 
-ARG LIQUIDSOAP_VERSION
-ARG OPAM_PACKAGES="liquidsoap${LIQUIDSOAP_VERSION:+.$LIQUIDSOAP_VERSION} taglib mad lame vorbis cry samplerate"
-
 USER radio
 
 # setup opam
-RUN opam init -a -y --disable-sandboxing && \
-    eval $(opam env) && \
-    opam install -y depext
+RUN opam init -a -y --disable-sandboxing --comp 4.14.2
 
 # install liquidsoap
-RUN opam depext -y ${OPAM_PACKAGES} && \
-    opam install -y ${OPAM_PACKAGES} && \
+RUN opam install -y ${OPAM_PACKAGES} && \
     eval $(opam env) && \
     opam clean -acryv --logs --unused-repositories
 


### PR DESCRIPTION
Fix building newer versions of liquidsoap that require a newer opam (fixes #19), add ffmpeg, ssl (supersedes #13), and jemalloc support, fix OCaml version to 4.14.2 to avoid GC issues with 5.x that result in roughly double the peak memory usage.